### PR TITLE
Move repository to mopidy org.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,2 @@
+- Thomas Kemmer <tkemmer@computer.org>
+- Stein Magnus Jodal <stein.magnus@jodal.no>

--- a/README.rst
+++ b/README.rst
@@ -82,12 +82,12 @@ Project Resources
     :target: https://pypi.python.org/pypi/Mopidy-Local-SQLite/
     :alt: Number of PyPI downloads
 
-.. image:: http://img.shields.io/travis/tkem/mopidy-local-sqlite/master.svg?style=flat
-    :target: https://travis-ci.org/tkem/mopidy-local-sqlite/
+.. image:: http://img.shields.io/travis/mopidy/mopidy-local-sqlite/master.svg?style=flat
+    :target: https://travis-ci.org/mopidy/mopidy-local-sqlite/
     :alt: Travis CI build status
 
-.. image:: http://img.shields.io/coveralls/tkem/mopidy-local-sqlite/master.svg?style=flat
-   :target: https://coveralls.io/r/tkem/mopidy-local-sqlite/
+.. image:: http://img.shields.io/coveralls/mopidy/mopidy-local-sqlite/master.svg?style=flat
+   :target: https://coveralls.io/r/mopidy/mopidy-local-sqlite/
    :alt: Test coverage
 
 - `Issue Tracker`_
@@ -98,7 +98,7 @@ Project Resources
 License
 ------------------------------------------------------------------------
 
-Copyright (c) 2014, 2015 Thomas Kemmer.
+Copyright (c) 2014, 2015 Thomas Kemmer and contributors_.
 
 Licensed under the `Apache License, Version 2.0`_.
 
@@ -118,8 +118,9 @@ affected by this.
 
 .. _pip: https://pip.pypa.io/en/latest/
 
-.. _Issue Tracker: https://github.com/tkem/mopidy-local-sqlite/issues/
-.. _Source Code: https://github.com/tkem/mopidy-local-sqlite/
-.. _Change Log: https://github.com/tkem/mopidy-local-sqlite/blob/master/CHANGES.rst
+.. _Issue Tracker: https://github.com/mopidy/mopidy-local-sqlite/issues/
+.. _Source Code: https://github.com/mopidy/mopidy-local-sqlite/
+.. _Change Log: https://github.com/mopidy/mopidy-local-sqlite/blob/master/CHANGES.rst
 
+.. _contributors: https://github.com/mopidy/mopidy-local-sqlite/blob/master/AUTHORS
 .. _Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def get_version(filename):
 setup(
     name='Mopidy-Local-SQLite',
     version=get_version('mopidy_local_sqlite/__init__.py'),
-    url='https://github.com/tkem/mopidy-local-sqlite',
+    url='https://github.com/mopidy/mopidy-local-sqlite',
     license='Apache License, Version 2.0',
     author='Thomas Kemmer',
     author_email='tkemmer@computer.org',


### PR DESCRIPTION
Changed links to point to mopidy org repo, added AUTHORS.
@jodal: Please let me know if anything else needs to be adapted to Mopidy's "corporate identity" guidelines.
Edit: Added @jodal to `AUTHORS` for Debian packaging, which will probably go into a new `debian` branch, just like the other extensions.