### PR TITLE
Use Extension().get_data_dir() if available

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+0.11 (UNRELEASED)
+-----------------
+
+- If used with Mopidy 1.1 or newer, the data dir provided by Mopidy to each
+  extension is used to store the SQLite database containing the music metadata.
+  If we can find the old data dir, all files are automatically moved to the new
+  data dir.
+
+
 0.10.3 2015-08-18
 -----------------
 

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -25,11 +25,17 @@ class LocalLibraryProviderTest(unittest.TestCase):
 
     def setUp(self):
         self.tempdir = tempfile.mkdtemp()
-        self.library = library.SQLiteLibrary(dict(self.config, local={
-            'media_dir': self.tempdir,
-            'data_dir': self.tempdir,
-            'excluded_file_extensions': []
-        }))
+        self.library = library.SQLiteLibrary(dict(
+            self.config,
+            core={
+                'data_dir': self.tempdir,
+            },
+            local={
+                'media_dir': self.tempdir,
+                'data_dir': self.tempdir,
+                'excluded_file_extensions': []
+            }
+        ))
         self.library.load()
 
     def tearDown(self):


### PR DESCRIPTION
`local/data_dir` goes away with Mopidy 1.1.1, making the current code
path crash, claiming that Mopidy-Local is disabled.