### PR TITLE
Fix #65: Remove file system ("Folders") browsing.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@
   If we can find the old data dir, all files are automatically moved to the new
   data dir.
 
+- Remove file system ("Folders") browsing, since this is already
+  handled by the `file` backend in Mopidy v1.1.
+
 
 0.10.3 2015-08-18
 -----------------

--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,6 @@ but be aware that these are still subject to change::
       Albums                  local:directory?type=album
       Artists                 local:directory?type=artist
       Composers               local:directory?type=artist&role=composer
-      Folders                 local:directory:
       Genres                  local:directory?type=genre
       Performers              local:directory?type=artist&role=performer
       Release Years           local:directory?type=date&format=%25Y

--- a/mopidy_local_sqlite/ext.conf
+++ b/mopidy_local_sqlite/ext.conf
@@ -6,7 +6,6 @@ directories =
     Albums                  local:directory?type=album
     Artists                 local:directory?type=artist
     Composers               local:directory?type=artist&role=composer
-    Folders                 local:directory:
     Genres                  local:directory?type=genre
     Performers              local:directory?type=artist&role=performer
     Release Years           local:directory?type=date&format=%25Y

--- a/mopidy_local_sqlite/schema.py
+++ b/mopidy_local_sqlite/schema.py
@@ -129,7 +129,6 @@ _SEARCH_FILTERS = {
     'date': "date LIKE ? || '%'",
     'genre': 'genre = ?',
     'performer': 'performer_uri = ?',
-    'uri': 'uri GLOB ?',
     'max-age': "last_modified >= (strftime('%s', 'now') - ?) * 1000",
 }
 


### PR DESCRIPTION
Already handled by the `file` extension in Mopidy v1.1.
Having two "standard" extensions that basically do the same thing might confuse users, especially since they use different configs/media directories.