### PR TITLE
Fix #58: Deprecate search_limit config value.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@
   If we can find the old data dir, all files are automatically moved to the new
   data dir.
 
+- Deprecate `search_limit` config value.
+
 
 0.10.3 2015-08-18
 -----------------

--- a/README.rst
+++ b/README.rst
@@ -65,11 +65,6 @@ but be aware that these are still subject to change::
   # multi-artist tracks [https://github.com/sampsyo/beets/issues/907]
   use_artist_mbid_uri = false
 
-  # override search limit provided by Mopidy core; set to -1 (no limit)
-  # to emulate current behavior of json library
-  # [https://github.com/mopidy/mopidy/issues/917]
-  search_limit = -1
-
 
 Project Resources
 ------------------------------------------------------------------------

--- a/mopidy_local_sqlite/__init__.py
+++ b/mopidy_local_sqlite/__init__.py
@@ -26,8 +26,8 @@ class Extension(ext.Extension):
         schema['timeout'] = config.Integer(optional=True, minimum=1)
         schema['use_album_mbid_uri'] = config.Boolean()
         schema['use_artist_mbid_uri'] = config.Boolean()
-        schema['search_limit'] = config.Integer(optional=True)
         # no longer used
+        schema['search_limit'] = config.Deprecated()
         schema['extract_images'] = config.Deprecated()
         schema['image_dir'] = config.Deprecated()
         schema['image_base_uri'] = config.Deprecated()

--- a/mopidy_local_sqlite/ext.conf
+++ b/mopidy_local_sqlite/ext.conf
@@ -24,8 +24,3 @@ use_album_mbid_uri = true
 # disabled by default, since some taggers do not handle this well for
 # multi-artist tracks [https://github.com/sampsyo/beets/issues/907]
 use_artist_mbid_uri = false
-
-# override search limit provided by Mopidy core; set to -1 (no limit)
-# to emulate current behavior of json library
-# [https://github.com/mopidy/mopidy/issues/917]
-search_limit = -1

--- a/mopidy_local_sqlite/library.py
+++ b/mopidy_local_sqlite/library.py
@@ -101,9 +101,6 @@ class SQLiteLibrary(local.Library):
         q = []
         for field, values in (query.items() if query else []):
             q.extend((field, value) for value in values)
-        # temporary workaround until Mopidy core sets limit
-        if self._config['search_limit'] is not None:
-            limit = self._config['search_limit']
         filters = [f for uri in uris or [] for f in self._filters(uri) if f]
         with self._connect() as c:
             tracks = schema.search_tracks(c, q, limit, offset, exact, filters)

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -17,4 +17,3 @@ def test_get_config_schema():
     assert 'timeout' in schema
     assert 'use_album_mbid_uri' in schema
     assert 'use_artist_mbid_uri' in schema
-    assert 'search_limit' in schema


### PR DESCRIPTION
This was originally a workaround for the `mopidy.local.Library.search()` `limit` argument being set to 100, which had negative side effects on MPD's `list` commands.
Now that `list` is implemented using `get_distinct()`, this is no longer an issue, and the workaround can be removed.