### PR TITLE
Fix #68: Require Mopidy v1.1.

### DIFF
--- a/mopidy_local_sqlite/__init__.py
+++ b/mopidy_local_sqlite/__init__.py
@@ -40,22 +40,9 @@ class Extension(ext.Extension):
 
     @classmethod
     def get_or_create_data_dir(cls, config):
-        if hasattr(cls, 'get_data_dir'):
-            # Mopidy >= 1.1
-            data_dir = cls().get_data_dir(config)
-            migrate_old_data_dir(config, data_dir)
-            return data_dir
-        # Mopidy < 1.1
-        try:
-            data_dir = config['local']['data_dir']
-        except KeyError:
-            from mopidy.exceptions import ExtensionError
-            raise ExtensionError('Mopidy-Local not enabled')
-        path = os.path.join(data_dir, b'sqlite')
-        if not os.path.isdir(path):
-            logger.info('Creating directory %s', path)
-            os.makedirs(path, 0o755)
-        return path
+        data_dir = cls().get_data_dir(config)
+        migrate_old_data_dir(config, data_dir)
+        return data_dir
 
 
 def migrate_old_data_dir(config, new_dir):

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'setuptools',
-        'Mopidy >= 1.0',
+        'Mopidy >= 1.1',
         'Pykka >= 1.1',
         'uritools >= 1.0'
     ],


### PR DESCRIPTION
No need to check if Extension has `get_data_dir` when requiring Mopidy v1.1; other "hacks" and workarounds for older Mopidy already removed, AFAICS.