### PR TITLE
Return browse results in case-insensitive sort order.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,10 @@
   ordering results, if available.  Set ``use_artist_sortname = false``
   to sort according to sort according to the displayed name only.
 
+- Return browse results in case-insensitive sort order.  Note that
+  this will only work for ASCII characters due to SQLite's ``NOCASE``
+  limitations.
+
 - Remove file system ("Folders") browsing, since this is already
   handled by the ``file`` backend in Mopidy v1.1.
 

--- a/mopidy_local_sqlite/library.py
+++ b/mopidy_local_sqlite/library.py
@@ -134,7 +134,7 @@ class SQLiteLibrary(local.Library):
     def _browse_album(self, uri, order=('disc_no', 'track_no', 'name')):
         return schema.browse(self._connect(), Ref.TRACK, order, album=uri)
 
-    def _browse_artist(self, uri, order=('type', 'name')):
+    def _browse_artist(self, uri, order=('type', 'name COLLATE NOCASE')):
         with self._connect() as c:
             albums = schema.browse(c, Ref.ALBUM, order, albumartist=uri)
             refs = schema.browse(c, order=order, artist=uri)
@@ -154,7 +154,7 @@ class SQLiteLibrary(local.Library):
         albums.sort(key=operator.attrgetter('name'))
         return albums + tracks
 
-    def _browse_directory(self, uri, order=('type', 'name')):
+    def _browse_directory(self, uri, order=('type', 'name COLLATE NOCASE')):
         query = dict(uritools.urisplit(uri).getquerylist())
         type = query.pop('type', None)
         role = query.pop('role', None)
@@ -171,7 +171,7 @@ class SQLiteLibrary(local.Library):
         if type == Ref.TRACK and 'album' in query:
             order = ('disc_no', 'track_no', 'name')
         if type == Ref.ARTIST and self._config['use_artist_sortname']:
-            order = ('coalesce(sortname, name)',)
+            order = ('coalesce(sortname, name) COLLATE NOCASE',)
         roles = role or ('artist', 'albumartist')  # FIXME: re-think 'roles'...
 
         refs = []

--- a/mopidy_local_sqlite/schema.py
+++ b/mopidy_local_sqlite/schema.py
@@ -228,7 +228,7 @@ def exists(c, uri):
     return rows.fetchone()[0]
 
 
-def browse(c, type=None, order=('type', 'name'), **kwargs):
+def browse(c, type=None, order=('type', 'name COLLATE NOCASE'), **kwargs):
     filters, params = _filters(_BROWSE_FILTERS[type], **kwargs)
     sql = _BROWSE_QUERIES[type] % (
         ' AND '.join(filters) or '1',


### PR DESCRIPTION
See https://discuss.mopidy.com/t/alphabetical-sort-order-too-strict/686

Thought that this could be resolved using `sortname`, but even with a reasonably well-tagged, beets-based library, there are too many artists w/o a sortname field. And this only applies to artists, anyway.

Note that case-insensitive sorting only works for ASCII characters due to SQLite's `NOCASE` limitations. Alternatively, one can specify a custom collation function, but implementing such a function in Python would probably have too much of an performance impact.
