### PR TITLE
Disable use_artist_sortname by default.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,9 +8,10 @@
   If we can find the old data dir, all files are automatically moved to the new
   data dir.
 
-- By default, browsing artists will use the "sortname" field for
-  ordering results, if available.  Set ``use_artist_sortname = false``
-  to sort according to sort according to the displayed name only.
+- Add support for ordering artist browse results based on their
+  ``sortname`` fields.  Set ``use_artist_sortname = true`` to enable
+  this, but be aware this may give confusing results if not all
+  artists in the library have proper sortnames.
 
 - Remove file system ("Folders") browsing, since this is already
   handled by the ``file`` backend in Mopidy v1.1.

--- a/mopidy_local_sqlite/ext.conf
+++ b/mopidy_local_sqlite/ext.conf
@@ -24,6 +24,7 @@ use_album_mbid_uri = true
 # multi-artist tracks [https://github.com/sampsyo/beets/issues/907]
 use_artist_mbid_uri = false
 
-# whether to use the sortname field for sorting artist browse results;
-# set to false to sort according to displayed name only
-use_artist_sortname = true
+# whether to use the sortname field for ordering artist browse
+# results; disabled by default, since this may give confusing results
+# if not all artists in the library have proper sortnames
+use_artist_sortname = false


### PR DESCRIPTION
After doing some testing with the new setting, I think that the behavior will be confusing (i.e. generating issues/discussion) for most users. Even with a reasonably well-tagged, beets-based library, artist tend to show up in funny places, depending on whether there is a `sortname` field or not. Better to leave this option for "power users", or until we find a way to solve this somehow.
