### PR TITLE
Incremental commit of library updates

### DIFF
--- a/mopidy_local_sqlite/__init__.py
+++ b/mopidy_local_sqlite/__init__.py
@@ -27,6 +27,7 @@ class Extension(ext.Extension):
         schema['use_album_mbid_uri'] = config.Boolean()
         schema['use_artist_mbid_uri'] = config.Boolean()
         schema['use_artist_sortname'] = config.Boolean()
+        schema['changes_per_commit'] = config.Integer()
         # no longer used
         schema['search_limit'] = config.Deprecated()
         schema['extract_images'] = config.Deprecated()

--- a/mopidy_local_sqlite/ext.conf
+++ b/mopidy_local_sqlite/ext.conf
@@ -28,3 +28,7 @@ use_artist_mbid_uri = false
 # results; disabled by default, since this may give confusing results
 # if not all artists in the library have proper sortnames
 use_artist_sortname = false
+
+# Whether to do an incremental commit every X changes
+# -1 means only commit at the end
+changes_per_commit = -1

--- a/mopidy_local_sqlite/library.py
+++ b/mopidy_local_sqlite/library.py
@@ -39,7 +39,7 @@ class SQLiteLibrary(local.Library):
         self._dbpath = os.path.join(self._data_dir, b'library.db')
         self._connection = None
         self._changes_since_last_commit = 0
-        self._max_changes_since_last_commit = 100
+        self._max_changes_since_last_commit = ext_config["changes_per_commit"]
 
     def load(self):
         with self._connect() as connection:
@@ -94,7 +94,7 @@ class SQLiteLibrary(local.Library):
         return schema.tracks(self._connect())
 
     def _incremental_commit(self):
-        if self._changes_since_last_commit > self._max_changes_since_last_commit:
+        if self._changes_since_last_commit != -1 and self._changes_since_last_commit > self._max_changes_since_last_commit:
             self._connection.commit()
             self._changes_since_last_commit = 0
 

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -50,6 +50,20 @@ class LocalLibraryProviderTest(unittest.TestCase):
         self.library.close()
         self.assertEqual([track], self.library.lookup(uri))
 
+    def test_add_multiple(self):
+        name = b'Test.mp3'
+        uri = translator.path_to_local_track_uri(name)
+        track = Track(name=name, uri=uri)
+        self.library._max_changes_since_last_commit = 0
+        self.library.begin()
+        self.assertEqual(0, self.library._changes_since_last_commit)
+        self.library.add(track)
+        self.assertEqual(1, self.library._changes_since_last_commit)
+        self.library.add(track)
+        self.assertEqual(1, self.library._changes_since_last_commit)
+        self.library.close()
+        self.assertEqual([track], self.library.lookup(uri))
+
     def test_add_noname_utf8(self):
         name = u'Mi\xf0vikudags.mp3'
         uri = translator.path_to_local_track_uri(name.encode('utf-8'))

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -19,7 +19,8 @@ class LocalLibraryProviderTest(unittest.TestCase):
             'timeout': 1.0,
             'use_album_mbid_uri': False,
             'use_artist_mbid_uri': False,
-            'search_limit': None
+            'search_limit': None,
+            'changes_per_commit': -1
         }
     }
 


### PR DESCRIPTION
So, I've got a large library (~80k tracks) on a disk attached to a Raspberry Pi. When trying to do local scan with mopidy-local-sqlite it gets to the end of the scan and then crashes with OOM. I guessed this was due to a large number of updates in one go, and so I made a patch to make it commit every so many changes and this fixed the problem.