### PR TITLE
Fix Travis build with latest Mopidy stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,6 @@ language: python
 python:
   - "2.7_with_system_site_packages"
 
-addons:
-  apt:
-    sources:
-      - mopidy-stable
-    packages:
-      - mopidy
-
 env:
   - TOX_ENV=py27
   - TOX_ENV=flake8

--- a/tox.ini
+++ b/tox.ini
@@ -5,11 +5,10 @@ envlist = py27, flake8
 sitepackages = true
 deps =
     mock
-    mopidy==dev
     pytest
     pytest-cov
     pytest-xdist
-install_command = pip install --allow-unverified=mopidy --pre {opts} {packages}
+install_command = pip install --allow-unverified=mopidy --pre {packages}
 commands =
     py.test --basetemp={envtmpdir} --cov --cov-report=term-missing {posargs}
 


### PR DESCRIPTION
As you can see from such fun items as https://travis-ci.org/mopidy/mopidy-local-sqlite/jobs/112828386 the version of Ubuntu Travis uses by default (Precise) is so dated it can't install Mopidy stable. This PR swaps over to the newer version (Trusty), which fixes the build issue.
